### PR TITLE
Use standard namespace for kubevirt workspaces

### DIFF
--- a/kubevirt/cluster.tf
+++ b/kubevirt/cluster.tf
@@ -79,6 +79,7 @@ resource "coder_app" "code-server" {
 }
 
 data "kubernetes_namespace" "workspace" {
+  # count = data.coder_workspace.me.start_count
   metadata {
     name = "coder-workspaces"
   }
@@ -90,7 +91,7 @@ resource "kubernetes_manifest" "cluster" {
     "kind"       = "Cluster"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
       "labels" = {
         "cluster-name" = data.coder_workspace.me.name
       }
@@ -100,13 +101,13 @@ resource "kubernetes_manifest" "cluster" {
         "apiVersion" = "controlplane.cluster.x-k8s.io/v1beta1"
         "kind"       = "KubeadmControlPlane"
         "name"       = data.coder_workspace.me.name
-        "namespace"  = data.kubernetes_namespace.workspace.metadata.name
+        "namespace"  = data.kubernetes_namespace.workspace.metadata[0].name
       }
       "infrastructureRef" = {
         "apiVersion" = "infrastructure.cluster.x-k8s.io/v1alpha1"
         "kind"       = "KubevirtCluster"
         "name"       = data.coder_workspace.me.name
-        "namespace"  = data.kubernetes_namespace.workspace.metadata.name
+        "namespace"  = data.kubernetes_namespace.workspace.metadata[0].name
       }
       "clusterNetwork" = {
         "pods" = {
@@ -124,7 +125,7 @@ resource "kubernetes_manifest" "cluster" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -134,7 +135,7 @@ resource "kubernetes_manifest" "kvcluster" {
     "kind"       = "KubevirtCluster"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "controlPlaneServiceTemplate" = {
@@ -170,7 +171,7 @@ resource "kubernetes_manifest" "kvcluster" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -180,14 +181,14 @@ resource "kubernetes_manifest" "kubevirtmachinetemplate_control_plane" {
     "kind"       = "KubevirtMachineTemplate"
     "metadata" = {
       "name"      = "${data.coder_workspace.me.name}-cp"
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "template" = {
         "spec" = {
           "virtualMachineTemplate" = {
             "metadata" = {
-              "namespace" = data.kubernetes_namespace.workspace.metadata.name
+              "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
             }
             "spec" = {
               "runStrategy" = "Always"
@@ -195,7 +196,7 @@ resource "kubernetes_manifest" "kubevirtmachinetemplate_control_plane" {
                 {
                   "metadata" = {
                     "name"      = "${data.coder_workspace.me.name}-cp-dv"
-                    "namespace" = data.kubernetes_namespace.workspace.metadata.name
+                    "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
                   }
                   "spec" = {
                     "source" = {
@@ -253,7 +254,7 @@ resource "kubernetes_manifest" "kubevirtmachinetemplate_control_plane" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -263,7 +264,7 @@ resource "kubernetes_manifest" "kubeadmcontrolplane_control_plane" {
     "kind"       = "KubeadmControlPlane"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "kubeadmConfigSpec" = {
@@ -295,7 +296,7 @@ resource "kubernetes_manifest" "kubeadmcontrolplane_control_plane" {
           "apiVersion" = "infrastructure.cluster.x-k8s.io/v1alpha1"
           "kind"       = "KubevirtMachineTemplate"
           "name"       = "${data.coder_workspace.me.name}-cp"
-          "namespace"  = data.kubernetes_namespace.workspace.metadata.name
+          "namespace"  = data.kubernetes_namespace.workspace.metadata[0].name
         }
       }
       "replicas" = 1
@@ -304,7 +305,7 @@ resource "kubernetes_manifest" "kubeadmcontrolplane_control_plane" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -314,7 +315,7 @@ resource "kubernetes_manifest" "vm-data-volume" {
     "kind"       = "DataVolume"
     "metadata" = {
       "name"      = "${data.coder_workspace.me.name}-dv"
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "source" = {
@@ -334,7 +335,7 @@ resource "kubernetes_manifest" "vm-data-volume" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -344,7 +345,7 @@ resource "kubernetes_manifest" "kubevirtmachinetemplate_md_0" {
     "kind"       = "KubevirtMachineTemplate"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "template" = {
@@ -356,7 +357,7 @@ resource "kubernetes_manifest" "kubevirtmachinetemplate_md_0" {
                 {
                   "metadata" = {
                     "name"      = "${data.coder_workspace.me.name}-dv"
-                    "namespace" = data.kubernetes_namespace.workspace.metadata.name
+                    "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
                   }
                   "spec" = {
                     "source" = {
@@ -414,7 +415,7 @@ resource "kubernetes_manifest" "kubevirtmachinetemplate_md_0" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace,
+    data.kubernetes_namespace.workspace,
     kubernetes_manifest.vm-data-volume
   ]
 }
@@ -425,7 +426,7 @@ resource "kubernetes_manifest" "kubeadmconfigtemplate_md_0" {
     "kind"       = "KubeadmConfigTemplate"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     # "spec" = {
     #   "template" = {
@@ -442,7 +443,7 @@ resource "kubernetes_manifest" "kubeadmconfigtemplate_md_0" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -452,7 +453,7 @@ resource "kubernetes_manifest" "machinedeployment_md_0" {
     "kind"       = "MachineDeployment"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "clusterName" = data.coder_workspace.me.name
@@ -467,7 +468,7 @@ resource "kubernetes_manifest" "machinedeployment_md_0" {
               "apiVersion" = "bootstrap.cluster.x-k8s.io/v1beta1"
               "kind"       = "KubeadmConfigTemplate"
               "name"       = data.coder_workspace.me.name
-              "namespace"  = data.kubernetes_namespace.workspace.metadata.name
+              "namespace"  = data.kubernetes_namespace.workspace.metadata[0].name
             }
           }
           "clusterName" = "kv1"
@@ -475,7 +476,7 @@ resource "kubernetes_manifest" "machinedeployment_md_0" {
             "apiVersion" = "infrastructure.cluster.x-k8s.io/v1alpha1"
             "kind"       = "KubevirtMachineTemplate"
             "name"       = data.coder_workspace.me.name
-            "namespace"  = data.kubernetes_namespace.workspace.metadata.name
+            "namespace"  = data.kubernetes_namespace.workspace.metadata[0].name
           }
           "version" = "v1.23.5"
         }
@@ -484,7 +485,7 @@ resource "kubernetes_manifest" "machinedeployment_md_0" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -493,7 +494,7 @@ resource "kubernetes_manifest" "configmap_capi_init" {
     "kind" = "ConfigMap"
     "metadata" = {
       "name"      = "capi-init"
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "apiVersion" = "v1"
     "data" = {
@@ -508,7 +509,7 @@ resource "kubernetes_manifest" "configmap_capi_init" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 
@@ -531,7 +532,7 @@ resource "kubernetes_manifest" "configmap_capi_init" {
 #     "kind" = "Secret"
 #     "metadata" = {
 #       "name"      = "vcluster-kubeconfig"
-#       "namespace" = data.kubernetes_namespace.workspace.metadata.name
+#       "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
 #     }
 #     "apiVersion" = "v1"
 #     "type"       = "addons.cluster.x-k8s.io/resource-set"
@@ -564,7 +565,7 @@ resource "kubernetes_manifest" "clusterresourceset_capi_init" {
     "kind"       = "ClusterResourceSet"
     "metadata" = {
       "name"      = data.coder_workspace.me.name
-      "namespace" = data.kubernetes_namespace.workspace.metadata.name
+      "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
     }
     "spec" = {
       "clusterSelector" = {
@@ -587,7 +588,7 @@ resource "kubernetes_manifest" "clusterresourceset_capi_init" {
   }
 
   depends_on = [
-    kubernetes_namespace.workspace
+    data.kubernetes_namespace.workspace
   ]
 }
 # data "kubernetes_resource" "cluster-kubeconfig" {
@@ -599,7 +600,7 @@ resource "kubernetes_manifest" "clusterresourceset_capi_init" {
 #   }
 
 #   depends_on = [
-#     kubernetes_namespace.workspace,
+#     data.kubernetes_namespace.workspace,
 #     kubernetes_manifest.cluster,
 #     kubernetes_manifest.vcluster
 #   ]
@@ -615,7 +616,7 @@ resource "kubernetes_manifest" "clusterresourceset_capi_init" {
 #     "kind"       = "HTTPProxy"
 #     "metadata" = {
 #       "name"      = "${data.coder_workspace.me.name}-apiserver"
-#       "namespace" = data.kubernetes_namespace.workspace.metadata.name
+#       "namespace" = data.kubernetes_namespace.workspace.metadata[0].name
 #       "annotations" = {
 #         "projectcontour.io/ingress.class" = "contour-external"
 #       }
@@ -703,22 +704,21 @@ data "kubernetes_secret_v1" "kubeconfig" {
   ]
 }
 
-resource "coder_metadata" "kubeconfig" {
-  count       = data.coder_workspace.me.start_count
-  resource_id = kubernetes_namespace.workspace[0].id
-  item {
-    key   = "description"
-    value = "The kubeconfig to connect to the cluster with"
-  }
-  item {
-    key       = "kubeconfig"
-    value     = data.kubernetes_secret_v1.kubeconfig == null ? "" : data.kubernetes_secret_v1.kubeconfig.data.value
-    sensitive = true
-  }
+# resource "coder_metadata" "kubeconfig" {
+#   count       = data.coder_workspace.me.start_count
+#   resource_id = data.kubernetes_namespace.workspace[0].id
+#   item {
+#     key   = "description"
+#     value = "The kubeconfig to connect to the cluster with"
+#   }
+#   item {
+#     key       = "kubeconfig"
+#     value     = data.kubernetes_secret_v1.kubeconfig == null ? "" : data.kubernetes_secret_v1.kubeconfig.data.value
+#     sensitive = true
+#   }
 
-  depends_on = [
-    data.kubernetes_secret_v1.kubeconfig,
-    time_sleep.wait_50_seconds
-  ]
-}
-
+#   depends_on = [
+#     data.kubernetes_secret_v1.kubeconfig,
+#     time_sleep.wait_50_seconds
+#   ]
+# }


### PR DESCRIPTION
Don't provision a namespace for each workspace, due to reducing Coder ServiceAccount permissions.