### PR TITLE
add emacs-broadway template

### DIFF
--- a/emacs-broadway/README.md
+++ b/emacs-broadway/README.md
@@ -1,0 +1,113 @@
+---
+name: Develop in Kubernetes
+description: Get started with Kubernetes development.
+tags: [cloud, kubernetes]
+---
+
+# Getting started
+
+This template creates a pod running the `codercom/enterprise-base:ubuntu` image.
+
+## RBAC
+
+The Coder provisioner requires permission to administer pods to use this template. The template
+creates workspaces in a single Kubernetes namespace, using the `workspaces_namespace` parameter set
+while creating the template.
+
+Create a role as follows and bind it to the user or service account that runs the coder host.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["*"]
+```
+
+## Authentication
+
+This template can authenticate using in-cluster authentication, or using a kubeconfig local to the
+Coder host. For additional authentication options, consult the [Kubernetes provider
+documentation](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs).
+
+### kubeconfig on Coder host
+
+If the Coder host has a local `~/.kube/config`, you can use this to authenticate
+with Coder. Make sure this is done with same user that's running the `coder` service.
+
+To use this authentication, set the parameter `use_kubeconfig` to true.
+
+### In-cluster authentication
+
+If the Coder host runs in a Pod on the same Kubernetes cluster as you are creating workspaces in,
+you can use in-cluster authentication.
+
+To use this authentication, set the parameter `use_kubeconfig` to false.
+
+The Terraform provisioner will automatically use the service account associated with the pod to
+authenticate to Kubernetes. Be sure to bind a [role with appropriate permission](#rbac) to the
+service account. For example, assuming the Coder host runs in the same namespace as you intend
+to create workspaces:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coder
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coder
+subjects:
+  - kind: ServiceAccount
+    name: coder
+roleRef:
+  kind: Role
+  name: coder
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Then start the Coder host with `serviceAccountName: coder` in the pod spec.
+
+## Namespace
+
+The target namespace in which the pod will be deployed is defined via the `coder_workspace`
+variable. The namespace must exist prior to creating workspaces.
+
+## Persistence
+
+The `/home/coder` directory in this example is persisted via the attached PersistentVolumeClaim.
+Any data saved outside of this directory will be wiped when the workspace stops.
+
+Since most binary installations and environment configurations live outside of
+the `/home` directory, we suggest including these in the `startup_script` argument
+of the `coder_agent` resource block, which will run each time the workspace starts up.
+
+For example, when installing the `aws` CLI, the install script will place the
+`aws` binary in `/usr/local/bin/aws`. To ensure the `aws` CLI is persisted across
+workspace starts/stops, include the following code in the `coder_agent` resource
+block of your workspace template:
+
+```terraform
+resource "coder_agent" "main" {
+  startup_script = <<EOT
+    #!/bin/bash
+
+    # install AWS CLI
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    sudo ./aws/install
+  EOT
+}
+```
+
+## code-server
+
+`code-server` is installed via the `startup_script` argument in the `coder_agent`
+resource block. The `coder_app` resource is defined to access `code-server` through
+the dashboard UI over `localhost:13337`.

--- a/emacs-broadway/main.tf
+++ b/emacs-broadway/main.tf
@@ -1,0 +1,154 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "0.6.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.12.1"
+    }
+  }
+}
+
+variable "use_kubeconfig" {
+  type        = bool
+  default     = false
+  sensitive   = true
+  description = <<-EOF
+  Use host kubeconfig? (true/false)
+
+  Set this to false if the Coder host is itself running as a Pod on the same
+  Kubernetes cluster as you are deploying workspaces to.
+
+  Set this to true if the Coder host is running outside the Kubernetes cluster
+  for workspaces.  A valid "~/.kube/config" must be present on the Coder host.
+  EOF
+}
+
+variable "namespace" {
+  type        = string
+  sensitive   = true
+  description = "The namespace to create workspaces in (must exist prior to creating workspaces)"
+  default     = "coder"
+}
+
+provider "kubernetes" {
+  # Authenticate via ~/.kube/config or a Coder-specific ServiceAccount, depending on admin preferences
+  config_path = var.use_kubeconfig == true ? "~/.kube/config" : null
+}
+
+data "coder_workspace" "me" {}
+
+resource "coder_agent" "main" {
+  os             = "linux"
+  arch           = "amd64"
+  startup_script = <<EOT
+    #!/bin/bash
+
+    # home folder currently contains .emacs.d and .doom.d
+    # at some point later we'll move them to another folder
+    sudo apt-get install -y tmux ttyd libwebsockets-evlib-uv
+    # start broadwayd and emacs
+    broadwayd :5 2>&1 | tee broadwayd.log &
+    GDK_BACKEND=broadway BROADWAY_DISPLAY=:5 emacs 2>&1 | tee emacs.log &
+    # start ttyd / tmux
+    tmux new -d
+    ttyd tmux at 2>&1 | tee ttyd.log &
+    # install and start code-server
+    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    code-server --auth none --port 13337 | tee code-server-install.log &
+
+  EOT
+}
+
+# emacs-broadway
+resource "coder_app" "emacs-broadway" {
+  subdomain    = false
+  share        = "public"
+  agent_id     = coder_agent.main.id
+  slug         = "emacs-broadway"
+  display_name = "Emacs on Broadway"
+  icon         = "/icon/folder.svg"      # let's maybe get an emacs.svg somehow
+  url          = "http://localhost:8085" # port 8080 + BROADWAY_DISPLAY
+
+  # healthcheck {
+  #   # don't want to disconnect current session, but hopefully this will 200OK
+  #   url       = "http://localhost:8085/"
+  #   interval  = 3
+  #   threshold = 10
+  # }
+}
+
+# ttyd
+resource "coder_app" "ttyd" {
+  subdomain    = false
+  share        = "public"
+  slug         = "ttyd"
+  display_name = "ttyd for tmux"
+  icon         = "/icon/folder.svg" # let's maybe get an emacs.svg somehow
+  agent_id     = coder_agent.main.id
+  url          = "http://localhost:7681" # 7681 is the default ttyd port
+
+  # healthcheck {
+  #   # don't want to disconnect current session, but hopefully this will 200OK
+  #   url       = "http://localhost:7681/"
+  #   interval  = 3
+  #   threshold = 10
+  # }
+}
+
+# tmux
+resource "coder_app" "tmux" {
+  agent_id     = coder_agent.main.id
+  display_name = "tmux"
+  slug         = "tmux"
+  icon         = "/icon/folder.svg" # let's maybe get an emacs.svg somehow
+  command      = "tmux at"
+  share        = "public"
+}
+
+# code-server
+resource "coder_app" "code-server" {
+  agent_id     = coder_agent.main.id
+  display_name = "code-server"
+  slug         = "code-server"
+  icon         = "/icon/code.svg"
+  url          = "http://localhost:13337?folder=/home/coder"
+  subdomain    = false
+
+  # healthcheck {
+  #   url       = "http://localhost:13337/healthz"
+  #   interval  = 3
+  #   threshold = 10
+  # }
+}
+
+resource "kubernetes_pod" "main" {
+  count = data.coder_workspace.me.start_count
+  metadata {
+    name      = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
+    namespace = var.namespace
+    labels = {
+      name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
+    }
+  }
+  spec {
+    security_context {
+      run_as_user = "1000"
+      fs_group    = "1000"
+    }
+    container {
+      name    = "dev"
+      image   = "ghcr.io/ii/emacs-coder:latest"
+      command = ["sh", "-c", coder_agent.main.init_script]
+      security_context {
+        run_as_user = "1000"
+      }
+      env {
+        name  = "CODER_AGENT_TOKEN"
+        value = coder_agent.main.token
+      }
+    }
+  }
+}


### PR DESCRIPTION
This template requires https://github.com/coder/coder/pull/5334

As there is an issue with the default go-lang http header handling library not preserving the header case for websocket connections expected by Broadway.